### PR TITLE
Add corncobs decoding

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -99,6 +99,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06ea2b9bc92be3c2baa9334a323ebca2d6f074ff852cd1d7b11064035cd3868f"
 
 [[package]]
+name = "corncobs"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9236877021b66ad90f833d8a73a7acb702b985b64c5986682d9f1f1a184f0fb"
+
+[[package]]
 name = "futures"
 version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -436,6 +442,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "array_pool",
+ "corncobs",
  "tokio",
  "tokio-serial",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,5 +8,6 @@ publish = false
 [dependencies]
 anyhow = "1.0.86"
 array_pool = "0.1.2"
+corncobs = "0.1.3"
 tokio = { version = "1.38.0", features = ["full"] }
 tokio-serial = "5.4.4"

--- a/src/packet.rs
+++ b/src/packet.rs
@@ -1,0 +1,52 @@
+use std::ops::{Deref, DerefMut};
+
+use array_pool::pool::BorrowingSlice;
+
+/// A slice of data transmitted over the wire.
+pub struct DataSlice {
+    buffer: BorrowingSlice<u8>,
+    size: usize,
+}
+
+impl DataSlice {
+    pub fn new(buffer: BorrowingSlice<u8>, size: usize) -> Self {
+        assert!(buffer.len() >= size);
+        Self { buffer, size }
+    }
+
+    #[allow(unused)]
+    pub fn len(&self) -> usize {
+        self.size
+    }
+
+    #[allow(unused)]
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+}
+
+impl AsRef<[u8]> for DataSlice {
+    fn as_ref(&self) -> &[u8] {
+        &self.buffer[..self.size]
+    }
+}
+
+impl AsMut<[u8]> for DataSlice {
+    fn as_mut(&mut self) -> &mut [u8] {
+        &mut self.buffer[..self.size]
+    }
+}
+
+impl Deref for DataSlice {
+    type Target = [u8];
+
+    fn deref(&self) -> &Self::Target {
+        self.as_ref()
+    }
+}
+
+impl DerefMut for DataSlice {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        self.as_mut()
+    }
+}


### PR DESCRIPTION
This adds [Consistent Overhead Byte Stuffing (COBS)](https://en.wikipedia.org/wiki/Consistent_Overhead_Byte_Stuffing) decoding via [corncobs](https://docs.rs/corncobs/latest/corncobs/). Tandem to https://github.com/sunsided/stm32f3disco-rust/pull/5.